### PR TITLE
Right Transitions to right margin

### DIFF
--- a/textplay
+++ b/textplay
@@ -689,8 +689,8 @@ font-weight: #{bold_sluglines};
 /* Right Transitions */
 
 h3 {
-margin-left: 4in;
-width: 2in;
+text-align: right;
+width: 100%;
 }
 
 /* Left Transitions */


### PR DESCRIPTION
Transitions like `CUT TO:` and `MATCH CUT TO:` could be aligned with the right margin of the page. This makes for a much cleaner HTML and PDF output.
