### PR TITLE
Strip DOS style line endings in input file

### DIFF
--- a/textplay
+++ b/textplay
@@ -734,6 +734,9 @@ xmlEnd = '</root>'
 
 # NOTE: PHASE 4 - Convert input to XML
 
+# Remove any DOS-style line endings:
+text = text.gsub(/\r\n/, "\n")
+
 # Misc Encoding
 text = text.gsub(/^[ \t]*([=-]{3,})[ \t]*$/, '<page-break />')
 text = text.gsub(/&/, '&#38;')


### PR DESCRIPTION
Was momentarily confused because textplay was just passing my script through unmodified (except for header/footer). Turned out to be because my file (exported from celtx in Ubuntu) had DOS line endings. I don't do ruby, but this simple fix works for me.